### PR TITLE
Hide fraud prevention code by default

### DIFF
--- a/src/pages/pay/tab-lookup/tab-lookup.html
+++ b/src/pages/pay/tab-lookup/tab-lookup.html
@@ -39,8 +39,14 @@
           </ion-card-header>
           <ion-card-content id="fraud-prevention-code">
             <p>If requested, show this code to your server:</p>
-            <h2>{{fraudPreventionCode?.code}}</h2>
-            <p id="date-time">{{dateTime | date: 'mediumTime'}}</p>
+            <button ion-button block clear icon-end color="tabify" (click)="isCodeVisible = !isCodeVisible">
+              {{ isCodeVisible ? 'Hide Code' : 'Reveal Code' }}
+              <ion-icon [name]="isCodeVisible ? 'md-arrow-dropdown' : 'md-arrow-dropright'"></ion-icon>
+            </button>
+            <ng-container *ngIf="isCodeVisible">
+              <h2>{{fraudPreventionCode?.code}}</h2>
+              <p id="date-time">{{dateTime | date: 'mediumTime'}}</p>
+            </ng-container>
           </ion-card-content>
         </ion-card>
       </ion-col>

--- a/src/pages/pay/tab-lookup/tab-lookup.ts
+++ b/src/pages/pay/tab-lookup/tab-lookup.ts
@@ -20,6 +20,7 @@ export class TabLookupPage {
   tabForm: FormGroup;
   fraudPreventionCode!: IFraudPreventionCode;
   dateTime: number = Date.now();
+  isCodeVisible = false;
 
   constructor(
     public navCtrl: NavController,


### PR DESCRIPTION
Cleans up the tab lookup page by hiding the fraud prevention code and adding a button to reveal it when needed.