### PR TITLE
Remove pay nav button from checkout page.

### DIFF
--- a/src/pages/pay/tax-tip/tax-tip.html
+++ b/src/pages/pay/tax-tip/tax-tip.html
@@ -1,12 +1,6 @@
 <ion-header>
   <ion-navbar hideBackButton>
     <ion-title>Checkout</ion-title>
-    <ion-buttons end>
-      <button ion-button icon-end (click)="pay()">
-        Pay
-        <ion-icon name="arrow-forward"></ion-icon>
-      </button>
-    </ion-buttons>
   </ion-navbar>
 </ion-header>
 


### PR DESCRIPTION
@smalhotra3599 I'm not sure how this snuck back into the checkout page, but it happened after merging in the waiting room.